### PR TITLE
Issue #97

### DIFF
--- a/server/announce.go
+++ b/server/announce.go
@@ -146,7 +146,7 @@ func (a *announceData) removeFromKVStorage(subkey string) {
 }
 
 func (a *announceData) infoHashExists() bool {
-	return RedisGetBoolKeyVal(a.redisClient, a.info_hash, a)
+	return RedisGetBoolKeyVal(a.redisClient, a.info_hash)
 }
 
 func (a *announceData) createInfoHashKey() {

--- a/server/announce_response.go
+++ b/server/announce_response.go
@@ -70,8 +70,8 @@ func formatResponseData(ips []string, data *announceData) string {
 // string that we respond with.
 func EncodeResponse(ipport []string, data *announceData) (resp string) {
 	ret := ""
-	completeCount := len(RedisGetKeyVal(data.redisClient, data.info_hash, data))
-	incompleteCount := len(RedisGetKeyVal(data.redisClient, data.info_hash, data))
+	completeCount := len(RedisGetKeyVal(data, data.info_hash))
+	incompleteCount := len(RedisGetKeyVal(data, data.info_hash))
 	ret += bencode.EncodeKV("complete", bencode.EncodeInt(completeCount))
 
 	ret += bencode.EncodeKV("incomplete", bencode.EncodeInt(incompleteCount))

--- a/server/redis_test.go
+++ b/server/redis_test.go
@@ -42,7 +42,7 @@ func TestRedisSetKeyVal(t *testing.T) {
 
 func TestRedisGetKeyVal(t *testing.T) {
     DATA.redisClient.SAdd("RedisGetKeyValTest:1024:complete", "1024")
-    ret := RedisGetKeyVal(DATA.redisClient, "RedisGetKeyValTest:1024", &DATA)
+    ret := RedisGetKeyVal(&DATA, "RedisGetKeyValTest:1024")
     expectedReturn := ">1"
 
     if len(ret) == 0 {
@@ -52,7 +52,7 @@ func TestRedisGetKeyVal(t *testing.T) {
 
 func TestRedisGetKeyValNoPreexistKey(t *testing.T) {
     DATA.redisClient.SAdd("RedisGetKeyValTest:1025", "1024")
-    ret := RedisGetKeyVal(DATA.redisClient, "RedisGetKeyValTest:1025", &DATA)
+    ret := RedisGetKeyVal(&DATA, "RedisGetKeyValTest:1025")
     expectedReturn := 0
 
     if len(ret) != expectedReturn {
@@ -126,7 +126,7 @@ func TestRedisGetBoolKeyVal(t *testing.T) {
     RedisSetKeyVal(DATA.redisClient, "TestRedisGetBoolKeyVal", "1024")
 
     expectedReturn := true
-    ret := RedisGetBoolKeyVal(DATA.redisClient, "TestRedisGetBoolKeyVal", "1024")
+    ret := RedisGetBoolKeyVal(DATA.redisClient, "TestRedisGetBoolKeyVal")
 
     if ret != expectedReturn {
         t.Fatalf("Expected %v, got %v", expectedReturn, ret)
@@ -177,7 +177,7 @@ func TestRedisGetAllPeers(t *testing.T) {
     DATA.redisClient.SAdd("TestRedisGetAllPeers:complete", "1237")
     DATA.redisClient.SAdd("TestRedisGetAllPeers:complete", "1238")
 
-    ret := RedisGetAllPeers(DATA.redisClient, "TestRedisGetAllPeers", &DATA)
+    ret := RedisGetAllPeers(&DATA, "TestRedisGetAllPeers")
     x := len(ret)
 
     if x != 4 {
@@ -235,7 +235,7 @@ func TestRedisGetAllPeersValGT30(t *testing.T) {
     DATA.redisClient.SAdd("TestRedisGetAllPeers1:complete", "1234")
     DATA.redisClient.SAdd("TestRedisGetAllPeers1:complete", "1235")
 
-    ret := RedisGetAllPeers(DATA.redisClient, "TestRedisGetAllPeers1", &DATA)
+    ret := RedisGetAllPeers(&DATA, "TestRedisGetAllPeers1")
     x := len(ret)
 
     if x != 30 {
@@ -294,7 +294,7 @@ func TestRedisGetAllPeersValLT30(t *testing.T) {
     DATA.redisClient.SAdd("TestRedisGetAllPeers2:incomplete", "1234")
     DATA.redisClient.SAdd("TestRedisGetAllPeers2:incomplete", "1235")
 
-    ret := RedisGetAllPeers(DATA.redisClient, "TestRedisGetAllPeers2", &DATA)
+    ret := RedisGetAllPeers(&DATA, "TestRedisGetAllPeers2")
     x := len(ret)
 
     if x != 30 {

--- a/server/server.go
+++ b/server/server.go
@@ -10,8 +10,8 @@ import (
 var FIELDS = []string{"port", "uploaded", "downloaded", "left", "event", "compact"}
 
 func worker(data *announceData) []string {
-	if RedisGetBoolKeyVal(data.redisClient, data.info_hash, data) {
-		x := RedisGetKeyVal(data.redisClient, data.info_hash, data)
+	if RedisGetBoolKeyVal(data.redisClient, data.info_hash) {
+		x := RedisGetKeyVal(data, data.info_hash)
 
 		RedisSetIPMember(data)
 
@@ -48,7 +48,7 @@ func requestHandler(w http.ResponseWriter, req *http.Request) {
 
 	if data.event == "started" || data.event == "completed" {
 		worker(data)
-		x := RedisGetAllPeers(data.redisClient, data.info_hash, data)
+		x := RedisGetAllPeers(data, data.info_hash)
 
 		if len(x) > 0 {
 			w.Header().Set("Content-Type", "text/plain")


### PR DESCRIPTION
CHANGE:
- redis.go: Changed any instance where redis.go functions expected a
  `redisClient` and a *announceData as two seperate paramters, to only expect
  on `data *announceData`
