### PR TITLE
Fixes #125

### DIFF
--- a/announce/announce.go
+++ b/announce/announce.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+// ParseAnnounceData handles getting the annunce data from a remote client and
+// parses it into an acceptable data structure.
 func (a *AnnounceData) ParseAnnounceData(req *http.Request) (err error) {
 	query := req.URL.Query()
 
@@ -161,11 +163,11 @@ func (a *AnnounceData) removeFromKVStorage(subkey string) {
 }
 
 func (a *AnnounceData) infoHashExists() bool {
-	return r.RedisGetBoolKeyVal(a.InfoHash)
+	return r.RedisGetBoolKeyVal(nil, a.InfoHash)
 }
 
 func (a *AnnounceData) createInfoHashKey() {
-	r.CreateNewTorrentKey(a.InfoHash)
+	r.CreateNewTorrentKey(nil, a.InfoHash)
 }
 
 // ParseInfoHash parses the encoded info hash. Such a simple solution for a

--- a/announce/announce.go
+++ b/announce/announce.go
@@ -2,11 +2,11 @@ package announce
 
 import (
 	"fmt"
+	r "github.com/GrappigPanda/notorious/kvStoreInterfaces"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
-    r "github.com/GrappigPanda/notorious/kvStoreInterfaces"
 )
 
 func (a *AnnounceData) ParseAnnounceData(req *http.Request) (err error) {

--- a/announce/definitions.go
+++ b/announce/definitions.go
@@ -14,8 +14,8 @@ const (
 type AnnounceData struct {
 	InfoHash string //20 byte sha1 hash
 	PeerID   string //max len 20
-	IP        string //optional
-	Event     string // TorrentEvent
+	IP       string //optional
+	Event    string // TorrentEvent
 
 	Port uint64 // port number the peer is listening
 	// on

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"github.com/spf13/viper"
-        "strconv"
+	"strconv"
 )
 
 // ConfigStruct holds the values that our config file holds
@@ -25,20 +25,20 @@ func LoadConfig() ConfigStruct {
 	viper.AddConfigPath("../")
 	viper.AddConfigPath("/etc/")
 
-        err := viper.ReadInConfig()
-        if err != nil {
-                panic("Failed to open config file")
-        }
+	err := viper.ReadInConfig()
+	if err != nil {
+		panic("Failed to open config file")
+	}
 
-        if viper.GetBool("UseEnvVariables") == true {
-                viper.AutomaticEnv()
-                viper.BindEnv("mysqluser")
-        }
+	if viper.GetBool("UseEnvVariables") == true {
+		viper.AutomaticEnv()
+		viper.BindEnv("mysqluser")
+	}
 
-        whitelist, err := strconv.ParseBool(viper.Get("whitelist").(string))
-        if err != nil {
-                whitelist = false
-        }
+	whitelist, err := strconv.ParseBool(viper.Get("whitelist").(string))
+	if err != nil {
+		whitelist = false
+	}
 
 	if viper.Get("MySQLPass").(string) != "" {
 		return ConfigStruct{

--- a/database/database.go
+++ b/database/database.go
@@ -55,7 +55,7 @@ func GetTorrent(infoHash string) (db *gorm.DB, t *Torrent, err error) {
 }
 
 // GetWhitelistedTorrent Retrieves a single whitelisted torrent by its infoHash
-func GetWhitelistedTorrent(infoHash string) (db *gorm.DB, t *White_Torrent, err error) {
+func GetWhitelistedTorrent(db *gorm.DB, infoHash string) (t *White_Torrent, err error) {
 	db = assertOpenConnection(db)
 
 	t = &White_Torrent{}

--- a/database/database.go
+++ b/database/database.go
@@ -9,18 +9,6 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 )
 
-// formatConnectStrings concatenates the data from the config file into a
-// usable MySQL connection string.
-func formatConnectString(c config.ConfigStruct) string {
-	return fmt.Sprintf("%v:%v@tcp(%v:%v)/%v?parseTime=true",
-		c.MySQLUser,
-		c.MySQLPass,
-		c.MySQLHost,
-		c.MySQLPort,
-		c.MySQLDB,
-	)
-}
-
 // OpenConnection does as its name dictates and opens a connection to the
 // MysqlHost listed in the config
 func OpenConnection() (db *gorm.DB, err error) {
@@ -36,6 +24,8 @@ func OpenConnection() (db *gorm.DB, err error) {
 
 // InitDB initializes database tables.
 func InitDB(db *gorm.DB) {
+	db = assertOpenConnection(db)
+
 	db.CreateTable(&White_Torrent{})
 	db.CreateTable(&Torrent{})
 	db.CreateTable(&TrackerStats{})
@@ -44,11 +34,8 @@ func InitDB(db *gorm.DB) {
 
 // AddWhitelistedTorrent adds a torrent to the whitelist so that they may be
 // used by the tracker in the future.
-func (t *White_Torrent) AddWhitelistedTorrent() bool {
-	db, err := OpenConnection()
-	if err != nil {
-		err = err
-	}
+func (t *White_Torrent) AddWhitelistedTorrent(db *gorm.DB) bool {
+	db = assertOpenConnection(db)
 
 	db.Create(t)
 	return db.NewRecord(t)
@@ -57,11 +44,9 @@ func (t *White_Torrent) AddWhitelistedTorrent() bool {
 // GetTorrent retrieves a torrent by its infoHash from the generic torrent
 // table in the database. Note: there's also a whitelisted torrent table
 // (`white_torrent`).
-func GetTorrent(infoHash string) (t *Torrent, err error) {
-	db, err := OpenConnection()
-	if err != nil {
-		err = err
-	}
+func GetTorrent(infoHash string) (db *gorm.DB, t *Torrent, err error) {
+	db = assertOpenConnection(db)
+
 	t = &Torrent{}
 
 	db.Where("info_hash = ?", infoHash).Find(&t)
@@ -70,11 +55,9 @@ func GetTorrent(infoHash string) (t *Torrent, err error) {
 }
 
 // GetWhitelistedTorrent Retrieves a single whitelisted torrent by its infoHash
-func GetWhitelistedTorrent(infoHash string) (t *White_Torrent, err error) {
-	db, err := OpenConnection()
-	if err != nil {
-		err = err
-	}
+func GetWhitelistedTorrent(infoHash string) (db *gorm.DB, t *White_Torrent, err error) {
+	db = assertOpenConnection(db)
+
 	t = &White_Torrent{}
 
 	x := db.Where("info_hash = ?", infoHash).First(&t)
@@ -86,11 +69,8 @@ func GetWhitelistedTorrent(infoHash string) (t *White_Torrent, err error) {
 }
 
 // UpdateStats Handles updating statistics relevant to our tracker.
-func UpdateStats(uploaded uint64, downloaded uint64) {
-	db, err := OpenConnection()
-	if err != nil {
-		err = err
-	}
+func UpdateStats(db *gorm.DB, uploaded uint64, downloaded uint64) {
+	db = assertOpenConnection(db)
 
 	ts := &TrackerStats{}
 	db.First(&ts)
@@ -104,11 +84,8 @@ func UpdateStats(uploaded uint64, downloaded uint64) {
 }
 
 // UpdateTorrentStats Handles updating statistics relevant to our tracker.
-func UpdateTorrentStats(seederDelta int64, leecherDelta int64) {
-	db, err := OpenConnection()
-	if err != nil {
-		err = err
-	}
+func UpdateTorrentStats(db *gorm.DB, seederDelta int64, leecherDelta int64) {
+	db = assertOpenConnection(db)
 
 	t := &Torrent{}
 	db.First(&t)
@@ -123,11 +100,8 @@ func UpdateTorrentStats(seederDelta int64, leecherDelta int64) {
 
 // UpdatePeerStats handles updating peer info like hits per ip, downloaded
 // amount, uploaded amounts.
-func UpdatePeerStats(uploaded uint64, downloaded uint64, ip string) {
-	db, err := OpenConnection()
-	if err != nil {
-		err = err
-	}
+func UpdatePeerStats(db *gorm.DB, uploaded uint64, downloaded uint64, ip string) {
+	db = assertOpenConnection(db)
 
 	ps := &Peer_Stats{Ip: ip}
 	db.First(&ps)
@@ -142,11 +116,8 @@ func UpdatePeerStats(uploaded uint64, downloaded uint64, ip string) {
 // GetWhitelistedTorrents allows us to retrieve all of the white listed
 // torrents. Mostly used for populating the Redis KV storage with all of our
 // whitelisted torrents.
-func GetWhitelistedTorrents() (x *sql.Rows, err error) {
-	db, err := OpenConnection()
-	if err != nil {
-		err = err
-	}
+func GetWhitelistedTorrents(db *gorm.DB) (x *sql.Rows, err error) {
+	db = assertOpenConnection(db)
 
 	x, err = db.Table("white_torrents").Rows()
 	if err != nil {
@@ -158,6 +129,35 @@ func GetWhitelistedTorrents() (x *sql.Rows, err error) {
 
 // ScrapeTorrent supports the Scrape convention
 func ScrapeTorrent(db *gorm.DB, infoHash string) (torrent *Torrent) {
+	db = assertOpenConnection(db)
+
 	db.Where("info_hash = ?", infoHash).First(&torrent)
 	return
+}
+
+// formatConnectStrings concatenates the data from the config file into a
+// usable MySQL connection string.
+func formatConnectString(c config.ConfigStruct) string {
+	return fmt.Sprintf("%v:%v@tcp(%v:%v)/%v?parseTime=true",
+		c.MySQLUser,
+		c.MySQLPass,
+		c.MySQLHost,
+		c.MySQLPort,
+		c.MySQLDB,
+	)
+}
+
+// assertOpenConnection handles asserting a connection passed into a sql
+// function is open, not nil. If nil, we'll create a new connection.
+func assertOpenConnection(db *gorm.DB) *gorm.DB {
+	var err error
+
+	if db == nil {
+		db, err = OpenConnection()
+		if err != nil {
+			err = err
+		}
+	}
+
+	return db
 }

--- a/database/database.go
+++ b/database/database.go
@@ -103,7 +103,7 @@ func UpdateStats(uploaded uint64, downloaded uint64) {
 	return
 }
 
-// UpdateStats Handles updating statistics relevant to our tracker.
+// UpdateTorrentStats Handles updating statistics relevant to our tracker.
 func UpdateTorrentStats(seederDelta int64, leecherDelta int64) {
 	db, err := OpenConnection()
 	if err != nil {
@@ -121,6 +121,8 @@ func UpdateTorrentStats(seederDelta int64, leecherDelta int64) {
 	return
 }
 
+// UpdatePeerStats handles updating peer info like hits per ip, downloaded
+// amount, uploaded amounts.
 func UpdatePeerStats(uploaded uint64, downloaded uint64, ip string) {
 	db, err := OpenConnection()
 	if err != nil {
@@ -137,7 +139,7 @@ func UpdatePeerStats(uploaded uint64, downloaded uint64, ip string) {
 	return
 }
 
-// GetWhitelistedTorrent allows us to retrieve all of the white listed
+// GetWhitelistedTorrents allows us to retrieve all of the white listed
 // torrents. Mostly used for populating the Redis KV storage with all of our
 // whitelisted torrents.
 func GetWhitelistedTorrents() (x *sql.Rows, err error) {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -24,7 +24,7 @@ func TestAddWhitelistedTorrent(t *testing.T) {
 		DateAdded: time.Now().Unix(),
 	}
 
-	if !newTorrent.AddWhitelistedTorrent() {
+	if !newTorrent.AddWhitelistedTorrent(nil) {
 		t.Fatalf("Failed to Add a whitelisted torrent")
 	}
 }
@@ -44,10 +44,10 @@ func TestGetWhitelistedTorrents(t *testing.T) {
 		DateAdded: time.Now().Unix(),
 	}
 
-	newTorrent.AddWhitelistedTorrent()
-	newTorrent2.AddWhitelistedTorrent()
+	newTorrent.AddWhitelistedTorrent(nil)
+	newTorrent2.AddWhitelistedTorrent(nil)
 
-	_, err := GetWhitelistedTorrents()
+	_, err := GetWhitelistedTorrents(nil)
 	if err != nil {
 		t.Fatalf("Failed to get all whitelisted torrents: %v", err)
 	}
@@ -61,9 +61,9 @@ func TestGetWhitelistedTorrent(t *testing.T) {
 		DateAdded: time.Now().Unix(),
 	}
 
-	newTorrent.AddWhitelistedTorrent()
+	newTorrent.AddWhitelistedTorrent(nil)
 
-	retval, err := GetWhitelistedTorrent(newTorrent.InfoHash)
+	retval, err := GetWhitelistedTorrent(nil, newTorrent.InfoHash)
 	if err != nil {
 		t.Fatalf("Failed to GetWhitelistedTorrent: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestUpdateStats(t *testing.T) {
 	}
 	DBCONN.Save(&newStats)
 
-	UpdateStats(20, 5)
+	UpdateStats(nil, 20, 5)
 
 	retval := &TrackerStats{}
 	DBCONN.First(&retval)
@@ -118,7 +118,7 @@ func TestUpdatePeerStats(t *testing.T) {
 
 	DBCONN.Save(&newPeer)
 
-	UpdatePeerStats(20, 5, "127.0.0.1")
+	UpdatePeerStats(nil, 20, 5, "127.0.0.1")
 
 	retval := &Peer_Stats{}
 	DBCONN.First(&retval)

--- a/main.go
+++ b/main.go
@@ -18,6 +18,5 @@ func Init() {
 }
 
 func main() {
-	Init()
 	server.RunServer()
 }

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -83,7 +83,7 @@ func StartReapingScheduler(waitTime time.Duration) {
 			addedBy := new(string)
 			dateAdded := new(int64)
 
-			x, err := db.GetWhitelistedTorrents()
+			x, err := db.GetWhitelistedTorrents(nil)
 			for x.Next() {
 				x.Scan(infoHash, name, addedBy, dateAdded)
 				r.CreateNewTorrentKey(nil, *infoHash)

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -86,7 +86,7 @@ func StartReapingScheduler(waitTime time.Duration) {
 			x, err := db.GetWhitelistedTorrents()
 			for x.Next() {
 				x.Scan(infoHash, name, addedBy, dateAdded)
-				r.CreateNewTorrentKey(*infoHash)
+				r.CreateNewTorrentKey(nil, *infoHash)
 			}
 
 			// Start the actual peer reaper.

--- a/server/announce_response.go
+++ b/server/announce_response.go
@@ -3,9 +3,9 @@ package server
 import (
 	"bytes"
 	"fmt"
+	. "github.com/GrappigPanda/notorious/announce"
 	"github.com/GrappigPanda/notorious/bencode"
 	"github.com/GrappigPanda/notorious/database"
-	. "github.com/GrappigPanda/notorious/announce"
 	r "github.com/GrappigPanda/notorious/kvStoreInterfaces"
 	"net"
 	"strconv"

--- a/server/announce_response.go
+++ b/server/announce_response.go
@@ -72,8 +72,8 @@ func formatResponseData(ips []string, data *AnnounceData) string {
 // string that we respond with.
 func EncodeResponse(ipport []string, data *AnnounceData) (resp string) {
 	ret := ""
-	completeCount := len(r.RedisGetKeyVal(data.InfoHash))
-	incompleteCount := len(r.RedisGetKeyVal(data.InfoHash))
+	completeCount := len(r.RedisGetKeyVal(nil, data.InfoHash))
+	incompleteCount := len(r.RedisGetKeyVal(nil, data.InfoHash))
 	ret += bencode.EncodeKV("complete", bencode.EncodeInt(completeCount))
 
 	ret += bencode.EncodeKV("incomplete", bencode.EncodeInt(incompleteCount))

--- a/server/peerStore/peerstore.go
+++ b/server/peerStore/peerstore.go
@@ -1,11 +1,11 @@
 package peerStore
 
 type PeerStore interface {
-    SetKeyIfNotExists(string, string) bool
-    SetKV(string, string) 
-    RemoveKV(string, string)
-    KeyExists(string) bool
-    GetKeyVal(string) []string
-    GetAllPeers(string) []string
-    SetIPMember(string, string) int
+	SetKeyIfNotExists(string, string) bool
+	SetKV(string, string)
+	RemoveKV(string, string)
+	KeyExists(string) bool
+	GetKeyVal(string) []string
+	GetAllPeers(string) []string
+	SetIPMember(string, string) int
 }

--- a/server/peerStore/redisStore.go
+++ b/server/peerStore/redisStore.go
@@ -5,18 +5,22 @@ import (
 	"gopkg.in/redis.v3"
 )
 
+// RedisStore represents the implementation of a `PeerStore` object.
 type RedisStore struct {
 	client *redis.Client
 }
 
+// SetKeyIfNotExists wraps around the generic RedisSetKeyIfNotExists function
 func (p *RedisStore) SetKeyIfNotExists(key, value string) (retval bool) {
 	return r.RedisSetKeyIfNotExists(p.client, key, value)
 }
 
+// SetKV wraps around the generic `RedisSetKeyVal` function
 func (p *RedisStore) SetKV(key, value string) {
 	r.RedisSetKeyVal(p.client, key, value)
 }
 
+// RemoveKV wraps around the specific `RedisRemoveKeysValue` function
 func (p *RedisStore) RemoveKV(key, value string) {
 	// TODO(ian): Refactor this so we don't have to delete a value from a key
 	if value != "" || value == "" {
@@ -24,18 +28,22 @@ func (p *RedisStore) RemoveKV(key, value string) {
 	}
 }
 
+// KeyExists wraps around the specific `RedisGetBoolKeyVal` function
 func (p *RedisStore) KeyExists(key string) (retval bool) {
-	return r.RedisGetBoolKeyVal(key)
+	return r.RedisGetBoolKeyVal(p.client, key)
 }
 
+// GetKeyVal wraps around the specific `RedisGetKeyVal` function
 func (p *RedisStore) GetKeyVal(key string) []string {
-	return r.RedisGetKeyVal(key)
+	return r.RedisGetKeyVal(p.client, key)
 }
 
+// GetAllPeers wraps around the specific `RedisGetAllPeers` function
 func (p *RedisStore) GetAllPeers(key string) []string {
-	return r.RedisGetAllPeers(key)
+	return r.RedisGetAllPeers(p.client, key)
 }
 
+// SetIPMember wraps around the specific `RedisSetIPMember` function
 func (p *RedisStore) SetIPMember(infoHash, ipPort string) (retval int) {
-	return r.RedisSetIPMember(infoHash, ipPort)
+	return r.RedisSetIPMember(p.client, infoHash, ipPort)
 }

--- a/server/peerStore/redisStore.go
+++ b/server/peerStore/redisStore.go
@@ -1,41 +1,41 @@
 package peerStore
 
 import (
-    r "github.com/GrappigPanda/notorious/kvStoreInterfaces"
+	r "github.com/GrappigPanda/notorious/kvStoreInterfaces"
 	"gopkg.in/redis.v3"
 )
 
 type RedisStore struct {
-    client *redis.Client
+	client *redis.Client
 }
 
 func (p *RedisStore) SetKeyIfNotExists(key, value string) (retval bool) {
-    return r.RedisSetKeyIfNotExists(p.client, key, value)
+	return r.RedisSetKeyIfNotExists(p.client, key, value)
 }
 
 func (p *RedisStore) SetKV(key, value string) {
-    r.RedisSetKeyVal(p.client, key, value)
+	r.RedisSetKeyVal(p.client, key, value)
 }
 
 func (p *RedisStore) RemoveKV(key, value string) {
-    // TODO(ian): Refactor this so we don't have to delete a value from a key
-    if value != "" || value == "" {
-        r.RedisRemoveKeysValue(p.client, key, value)
-    }
+	// TODO(ian): Refactor this so we don't have to delete a value from a key
+	if value != "" || value == "" {
+		r.RedisRemoveKeysValue(p.client, key, value)
+	}
 }
 
 func (p *RedisStore) KeyExists(key string) (retval bool) {
-    return r.RedisGetBoolKeyVal(key)
+	return r.RedisGetBoolKeyVal(key)
 }
 
 func (p *RedisStore) GetKeyVal(key string) []string {
-    return r.RedisGetKeyVal(key)
+	return r.RedisGetKeyVal(key)
 }
 
 func (p *RedisStore) GetAllPeers(key string) []string {
-    return r.RedisGetAllPeers(key)
+	return r.RedisGetAllPeers(key)
 }
 
 func (p *RedisStore) SetIPMember(infoHash, ipPort string) (retval int) {
-    return r.RedisSetIPMember(infoHash, ipPort)
+	return r.RedisSetIPMember(infoHash, ipPort)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -2,20 +2,20 @@ package server
 
 import (
 	"fmt"
+	. "github.com/GrappigPanda/notorious/announce"
 	"github.com/GrappigPanda/notorious/config"
 	"github.com/GrappigPanda/notorious/database"
-	. "github.com/GrappigPanda/notorious/announce"
-	"github.com/GrappigPanda/notorious/server/peerStore"
 	r "github.com/GrappigPanda/notorious/kvStoreInterfaces"
+	"github.com/GrappigPanda/notorious/server/peerStore"
 	"net/http"
 )
 
 // applicationContext houses data necessary for the handler to properly
 // function as the application is desired.
 type applicationContext struct {
-	config       config.ConfigStruct
-	trackerLevel int
-    peerStoreClient peerStore.PeerStore
+	config          config.ConfigStruct
+	trackerLevel    int
+	peerStoreClient peerStore.PeerStore
 }
 
 type scrapeData struct {
@@ -52,13 +52,13 @@ func (app *applicationContext) worker(data *AnnounceData) []string {
 	if app.peerStoreClient.KeyExists(data.InfoHash) {
 		x := app.peerStoreClient.GetKeyVal(data.InfoHash)
 
-        app.peerStoreClient.SetIPMember(data.InfoHash, fmt.Sprintf("%s:%s", data.IP, data.Port))
+		app.peerStoreClient.SetIPMember(data.InfoHash, fmt.Sprintf("%s:%s", data.IP, data.Port))
 
 		return x
 
 	} else {
-        r.CreateNewTorrentKey(data.InfoHash)
-    }
+		r.CreateNewTorrentKey(data.InfoHash)
+	}
 
 	return app.worker(data)
 }
@@ -90,7 +90,7 @@ func (app *applicationContext) requestHandler(w http.ResponseWriter, req *http.R
 
 	}
 
-    data.RequestContext.Whitelist = app.config.Whitelist
+	data.RequestContext.Whitelist = app.config.Whitelist
 
 	fmt.Printf("Event: %s from host %s on port %v\n", data.Event, data.IP, data.Port)
 
@@ -160,9 +160,9 @@ func writeResponse(w http.ResponseWriter, values string) {
 // RunServer spins up the server and muxes the routes.
 func RunServer() {
 	app := applicationContext{
-		config:       config.LoadConfig(),
-		trackerLevel: RATIOLESS,
-        peerStoreClient: new(peerStore.RedisStore),
+		config:          config.LoadConfig(),
+		trackerLevel:    RATIOLESS,
+		peerStoreClient: new(peerStore.RedisStore),
 	}
 
 	mux := http.NewServeMux()

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ type applicationContext struct {
 	config          config.ConfigStruct
 	trackerLevel    int
 	peerStoreClient peerStore.PeerStore
+	dbPool          *gorm.DB
 }
 
 type scrapeData struct {
@@ -64,21 +65,21 @@ func (app *applicationContext) worker(data *a.AnnounceData) []string {
 }
 
 func (app *applicationContext) handleStatsTracking(data *a.AnnounceData) {
-	db.UpdateStats(data.Uploaded, data.Downloaded)
+	db.UpdateStats(app.dbPool, data.Uploaded, data.Downloaded)
 
 	if app.trackerLevel > a.RATIOLESS {
-		db.UpdatePeerStats(data.Uploaded, data.Downloaded, data.IP)
+		db.UpdatePeerStats(app.dbPool, data.Uploaded, data.Downloaded, data.IP)
 	}
 
 	if data.Event == "completed" {
-		db.UpdateTorrentStats(1, -1)
+		db.UpdateTorrentStats(app.dbPool, 1, -1)
 		return
 	} else if data.Left == 0 {
 		// TODO(ian): Don't assume the peer is already in the DB
-		db.UpdateTorrentStats(1, -1)
+		db.UpdateTorrentStats(app.dbPool, 1, -1)
 		return
 	} else if data.Event == "started" {
-		db.UpdateTorrentStats(0, 1)
+		db.UpdateTorrentStats(app.dbPool, 0, 1)
 	}
 }
 
@@ -129,21 +130,19 @@ func (app *applicationContext) requestHandler(w http.ResponseWriter, req *http.R
 	app.handleStatsTracking(data)
 }
 
-func scrapeHandlerCurried(dbConn *gorm.DB) func(w http.ResponseWriter, req *http.Request) {
-	return func(w http.ResponseWriter, req *http.Request) {
-		query := req.URL.Query()
+func (app *applicationContext) scrapeHandler(w http.ResponseWriter, req *http.Request) {
+	query := req.URL.Query()
 
-		infoHash := query.Get("InfoHash")
-		if infoHash == "" {
-			failMsg := fmt.Sprintf("Tracker does not support multiple entire DB scrapes.")
-			writeErrorResponse(w, failMsg)
-		} else {
-			torrentData := db.ScrapeTorrent(dbConn, infoHash)
-			writeResponse(w, formatScrapeResponse(torrentData))
-		}
-
-		return
+	infoHash := query.Get("InfoHash")
+	if infoHash == "" {
+		failMsg := fmt.Sprintf("Tracker does not support multiple entire DB scrapes.")
+		writeErrorResponse(w, failMsg)
+	} else {
+		torrentData := db.ScrapeTorrent(app.dbPool, infoHash)
+		writeResponse(w, formatScrapeResponse(torrentData))
 	}
+
+	return
 }
 
 func writeErrorResponse(w http.ResponseWriter, failMsg string) {
@@ -157,22 +156,21 @@ func writeResponse(w http.ResponseWriter, values string) {
 
 // RunServer spins up the server and muxes the routes.
 func RunServer() {
-	app := applicationContext{
-		config:          config.LoadConfig(),
-		trackerLevel:    a.RATIOLESS,
-		peerStoreClient: new(peerStore.RedisStore),
-	}
-
-	mux := http.NewServeMux()
-
 	dbConn, err := db.OpenConnection()
 	if err != nil {
 		panic("Failed to open connection to remote database server.")
 	}
 
-	scrapeHandler := scrapeHandlerCurried(dbConn)
+	app := applicationContext{
+		config:          config.LoadConfig(),
+		trackerLevel:    a.RATIOLESS,
+		peerStoreClient: new(peerStore.RedisStore),
+		dbPool:          dbConn,
+	}
+
+	mux := http.NewServeMux()
 
 	mux.HandleFunc("/announce", app.requestHandler)
-	mux.HandleFunc("/scrape", scrapeHandler)
+	mux.HandleFunc("/scrape", app.scrapeHandler)
 	http.ListenAndServe(":3000", mux)
 }


### PR DESCRIPTION
ADD:
  - database/database.go:assertOpenConnection() now asserts a passed in
    connection object is not nil, if it is nil then we will open a new
    connection. This massively cuts down on opening/closing of connections
    during runtime vs initialization.

CHANGE:
  - reaper/reaper.go Updating for changes in `database/database.go`. See `ADD`
    section.
  - server/server.go Added a `dbPool` object to the `applicationContext` and
    updated for changes in `database/database.go`.
  - database/database.go Updating some comments.
  - server/server.go Added a curried `scrapeHandler` which uses a database
    pool.