### PR TITLE
Fixes #152

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ func LoadConfig() ConfigStruct {
 	viper.AddConfigPath(".")
 	viper.AddConfigPath("../")
 	viper.AddConfigPath("/etc/")
+	viper.AddConfigPath("$GOPATH/src/github.com/GrappigPanda/notorious/")
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/database/database.go
+++ b/database/database.go
@@ -7,6 +7,13 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 )
 
+// AddWhitelistedTorrent handles adding a new whitelisted torrent into the
+// database.
+func (t *White_Torrent) AddWhitelistedTorrent(db *gorm.DB) bool {
+	db.Create(t)
+	return db.NewRecord(t)
+}
+
 // SQLStore is the base implementation for a database which will be used to
 // store stats and retrieve whitelisted torrents.
 type SQLStore interface {

--- a/database/database.go
+++ b/database/database.go
@@ -2,162 +2,20 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
-	"github.com/GrappigPanda/notorious/config"
 	"github.com/jinzhu/gorm"
 	// We use a blank import here because I'm afraid of breaking anything
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 )
 
-// OpenConnection does as its name dictates and opens a connection to the
-// MysqlHost listed in the config
-func OpenConnection() (db *gorm.DB, err error) {
-	c := config.LoadConfig()
-
-	db, err = gorm.Open("mysql", formatConnectString(c))
-	if err != nil {
-		err = fmt.Errorf("Failed to open connection to MySQL: %v", err)
-	}
-
-	return
-}
-
-// InitDB initializes database tables.
-func InitDB(db *gorm.DB) {
-	db = assertOpenConnection(db)
-
-	db.CreateTable(&White_Torrent{})
-	db.CreateTable(&Torrent{})
-	db.CreateTable(&TrackerStats{})
-	db.CreateTable(&Peer_Stats{})
-}
-
-// AddWhitelistedTorrent adds a torrent to the whitelist so that they may be
-// used by the tracker in the future.
-func (t *White_Torrent) AddWhitelistedTorrent(db *gorm.DB) bool {
-	db = assertOpenConnection(db)
-
-	db.Create(t)
-	return db.NewRecord(t)
-}
-
-// GetTorrent retrieves a torrent by its infoHash from the generic torrent
-// table in the database. Note: there's also a whitelisted torrent table
-// (`white_torrent`).
-func GetTorrent(infoHash string) (db *gorm.DB, t *Torrent, err error) {
-	db = assertOpenConnection(db)
-
-	t = &Torrent{}
-
-	db.Where("info_hash = ?", infoHash).Find(&t)
-
-	return
-}
-
-// GetWhitelistedTorrent Retrieves a single whitelisted torrent by its infoHash
-func GetWhitelistedTorrent(db *gorm.DB, infoHash string) (t *White_Torrent, err error) {
-	db = assertOpenConnection(db)
-
-	t = &White_Torrent{}
-
-	x := db.Where("info_hash = ?", infoHash).First(&t)
-	if x.Error != nil {
-		err = x.Error
-	}
-
-	return
-}
-
-// UpdateStats Handles updating statistics relevant to our tracker.
-func UpdateStats(db *gorm.DB, uploaded uint64, downloaded uint64) {
-	db = assertOpenConnection(db)
-
-	ts := &TrackerStats{}
-	db.First(&ts)
-	db.Model(&ts).Updates(
-		TrackerStats{
-			Uploaded:   ts.Uploaded + int64(uploaded),
-			Downloaded: ts.Downloaded + int64(downloaded),
-		})
-
-	return
-}
-
-// UpdateTorrentStats Handles updating statistics relevant to our tracker.
-func UpdateTorrentStats(db *gorm.DB, seederDelta int64, leecherDelta int64) {
-	db = assertOpenConnection(db)
-
-	t := &Torrent{}
-	db.First(&t)
-	db.Model(&t).Updates(
-		TrackerStats{
-			Uploaded:   t.Seeders + seederDelta,
-			Downloaded: t.Leechers + leecherDelta,
-		})
-
-	return
-}
-
-// UpdatePeerStats handles updating peer info like hits per ip, downloaded
-// amount, uploaded amounts.
-func UpdatePeerStats(db *gorm.DB, uploaded uint64, downloaded uint64, ip string) {
-	db = assertOpenConnection(db)
-
-	ps := &Peer_Stats{Ip: ip}
-	db.First(&ps)
-	db.Model(&ps).UpdateColumn(map[string]interface{}{
-		"Uploaded":   ps.Uploaded + int64(uploaded),
-		"Downloaded": ps.Downloaded + int64(downloaded),
-	})
-
-	return
-}
-
-// GetWhitelistedTorrents allows us to retrieve all of the white listed
-// torrents. Mostly used for populating the Redis KV storage with all of our
-// whitelisted torrents.
-func GetWhitelistedTorrents(db *gorm.DB) (x *sql.Rows, err error) {
-	db = assertOpenConnection(db)
-
-	x, err = db.Table("white_torrents").Rows()
-	if err != nil {
-		return
-	}
-
-	return
-}
-
-// ScrapeTorrent supports the Scrape convention
-func ScrapeTorrent(db *gorm.DB, infoHash string) (torrent *Torrent) {
-	db = assertOpenConnection(db)
-
-	db.Where("info_hash = ?", infoHash).First(&torrent)
-	return
-}
-
-// formatConnectStrings concatenates the data from the config file into a
-// usable MySQL connection string.
-func formatConnectString(c config.ConfigStruct) string {
-	return fmt.Sprintf("%v:%v@tcp(%v:%v)/%v?parseTime=true",
-		c.MySQLUser,
-		c.MySQLPass,
-		c.MySQLHost,
-		c.MySQLPort,
-		c.MySQLDB,
-	)
-}
-
-// assertOpenConnection handles asserting a connection passed into a sql
-// function is open, not nil. If nil, we'll create a new connection.
-func assertOpenConnection(db *gorm.DB) *gorm.DB {
-	var err error
-
-	if db == nil {
-		db, err = OpenConnection()
-		if err != nil {
-			err = err
-		}
-	}
-
-	return db
+// SQLStore is the base implementation for a database which will be used to
+// store stats and retrieve whitelisted torrents.
+type SQLStore interface {
+	OpenConnection() (*gorm.DB, error)
+	GetTorrent(string) (*Torrent, error)
+	GetWhitelistedTorrent(string) (*White_Torrent, error)
+	UpdateStats(uint64, uint64)
+	UpdateTorrentStats(int64, int64)
+	ScrapeTorrent(string) *Torrent
+	GetWhitelistedTorrents() (*sql.Rows, error)
+	UpdatePeerStats(uint64, uint64, string)
 }

--- a/database/impl/mysqlStore.go
+++ b/database/impl/mysqlStore.go
@@ -1,0 +1,55 @@
+package sqlStoreImpl
+
+import (
+	"database/sql"
+	"github.com/GrappigPanda/notorious/database"
+	"github.com/GrappigPanda/notorious/database/mysql"
+	"github.com/jinzhu/gorm"
+	// We use a blank import here because I'm afraid of breaking anything
+	_ "github.com/jinzhu/gorm/dialects/mysql"
+)
+
+// MySQLStore represents the mysql implementation of `SQLStore`
+type MySQLStore struct {
+	dbPool *gorm.DB
+}
+
+// OpenConnection wraps `mysql.OpenConnection`.
+func (m *MySQLStore) OpenConnection() (*gorm.DB, error) {
+	return mysql.OpenConnection()
+}
+
+// GetTorrent wraps `mysql.GetTorrent`.
+func (m *MySQLStore) GetTorrent(infoHash string) (*db.Torrent, error) {
+	return mysql.GetTorrent(m.dbPool, infoHash)
+}
+
+// GetWhitelistedTorrent wraps `mysql.GetWhitelistedTorrent`.
+func (m *MySQLStore) GetWhitelistedTorrent(infoHash string) (*db.White_Torrent, error) {
+	return mysql.GetWhitelistedTorrent(m.dbPool, infoHash)
+}
+
+// UpdateStats wraps `mysql.UpdateStats`.
+func (m *MySQLStore) UpdateStats(uploaded uint64, downloaded uint64) {
+	mysql.UpdateStats(m.dbPool, uploaded, downloaded)
+}
+
+// UpdateTorrentStats wraps `mysql.UpdateTorrentStats`.
+func (m *MySQLStore) UpdateTorrentStats(uploaded int64, downloaded int64) {
+	mysql.UpdateTorrentStats(m.dbPool, uploaded, downloaded)
+}
+
+// ScrapeTorrent wraps `mysql.ScrapeTorrent`.
+func (m *MySQLStore) ScrapeTorrent(infoHash string) *db.Torrent {
+	return mysql.ScrapeTorrent(m.dbPool, infoHash)
+}
+
+// GetWhitelistedTorrents wraps `mysql.GetWhitelistedTorrents`.
+func (m *MySQLStore) GetWhitelistedTorrents() (*sql.Rows, error) {
+	return mysql.GetWhitelistedTorrents(m.dbPool)
+}
+
+// UpdatePeerStats wraps `mysql.UpdatePeerStats`.
+func (m *MySQLStore) UpdatePeerStats(uint64, uint64, string) {
+
+}

--- a/database/mysql/database_test.go
+++ b/database/mysql/database_test.go
@@ -25,7 +25,7 @@ func TestAddWhitelistedTorrent(t *testing.T) {
 		DateAdded: time.Now().Unix(),
 	}
 
-	if !newTorrent.AddWhitelistedTorrent(nil) {
+	if !newTorrent.AddWhitelistedTorrent(DBCONN) {
 		t.Fatalf("Failed to Add a whitelisted torrent")
 	}
 }
@@ -45,10 +45,10 @@ func TestGetWhitelistedTorrents(t *testing.T) {
 		DateAdded: time.Now().Unix(),
 	}
 
-	newTorrent.AddWhitelistedTorrent(nil)
-	newTorrent2.AddWhitelistedTorrent(nil)
+	newTorrent.AddWhitelistedTorrent(DBCONN)
+	newTorrent2.AddWhitelistedTorrent(DBCONN)
 
-	_, err := GetWhitelistedTorrents(nil)
+	_, err := GetWhitelistedTorrents(DBCONN)
 	if err != nil {
 		t.Fatalf("Failed to get all whitelisted torrents: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestGetWhitelistedTorrent(t *testing.T) {
 		DateAdded: time.Now().Unix(),
 	}
 
-	newTorrent.AddWhitelistedTorrent(nil)
+	newTorrent.AddWhitelistedTorrent(DBCONN)
 
 	retval, err := GetWhitelistedTorrent(nil, newTorrent.InfoHash)
 	if err != nil {

--- a/database/mysql/database_test.go
+++ b/database/mysql/database_test.go
@@ -1,6 +1,7 @@
-package db
+package mysql
 
 import (
+	. "github.com/GrappigPanda/notorious/database"
 	"os"
 	"testing"
 	"time"

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -1,0 +1,155 @@
+package mysql
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/GrappigPanda/notorious/config"
+	"github.com/GrappigPanda/notorious/database"
+	"github.com/jinzhu/gorm"
+	// We use a blank import here because I'm afraid of breaking anything
+	_ "github.com/jinzhu/gorm/dialects/mysql"
+)
+
+// OpenConnection does as its name dictates and opens a connection to the
+// MysqlHost listed in the config
+func OpenConnection() (db *gorm.DB, err error) {
+	c := config.LoadConfig()
+
+	db, err = gorm.Open("mysql", formatConnectString(c))
+	if err != nil {
+		err = fmt.Errorf("Failed to open connection to MySQL: %v", err)
+	}
+
+	return
+}
+
+// InitDB initializes database tables.
+func InitDB(dbConn *gorm.DB) {
+	dbConn = assertOpenConnection(dbConn)
+
+	dbConn.CreateTable(&db.White_Torrent{})
+	dbConn.CreateTable(&db.Torrent{})
+	dbConn.CreateTable(&db.TrackerStats{})
+	dbConn.CreateTable(&db.Peer_Stats{})
+}
+
+// GetTorrent retrieves a torrent by its infoHash from the generic torrent
+// table in the database. Note: there's also a whitelisted torrent table
+// (`white_torrent`).
+func GetTorrent(dbConn *gorm.DB, infoHash string) (t *db.Torrent, err error) {
+	dbConn = assertOpenConnection(dbConn)
+
+	t = &db.Torrent{}
+
+	dbConn.Where("info_hash = ?", infoHash).Find(&t)
+
+	return
+}
+
+// GetWhitelistedTorrent Retrieves a single whitelisted torrent by its infoHash
+func GetWhitelistedTorrent(dbConn *gorm.DB, infoHash string) (t *db.White_Torrent, err error) {
+	dbConn = assertOpenConnection(dbConn)
+
+	t = &db.White_Torrent{}
+
+	x := dbConn.Where("info_hash = ?", infoHash).First(&t)
+	if x.Error != nil {
+		err = x.Error
+	}
+
+	return
+}
+
+// UpdateStats Handles updating statistics relevant to our tracker.
+func UpdateStats(dbConn *gorm.DB, uploaded uint64, downloaded uint64) {
+	dbConn = assertOpenConnection(dbConn)
+
+	ts := &db.TrackerStats{}
+	dbConn.First(&ts)
+	dbConn.Model(&ts).Updates(
+		db.TrackerStats{
+			Uploaded:   ts.Uploaded + int64(uploaded),
+			Downloaded: ts.Downloaded + int64(downloaded),
+		})
+
+	return
+}
+
+// UpdateTorrentStats Handles updating statistics relevant to our tracker.
+func UpdateTorrentStats(dbConn *gorm.DB, seederDelta int64, leecherDelta int64) {
+	dbConn = assertOpenConnection(dbConn)
+
+	t := &db.Torrent{}
+	dbConn.First(&t)
+	dbConn.Model(&t).Updates(
+		db.TrackerStats{
+			Uploaded:   t.Seeders + seederDelta,
+			Downloaded: t.Leechers + leecherDelta,
+		})
+
+	return
+}
+
+// UpdatePeerStats handles updating peer info like hits per ip, downloaded
+// amount, uploaded amounts.
+func UpdatePeerStats(dbConn *gorm.DB, uploaded uint64, downloaded uint64, ip string) {
+	dbConn = assertOpenConnection(dbConn)
+
+	ps := &db.Peer_Stats{Ip: ip}
+	dbConn.First(&ps)
+	dbConn.Model(&ps).UpdateColumn(map[string]interface{}{
+		"Uploaded":   ps.Uploaded + int64(uploaded),
+		"Downloaded": ps.Downloaded + int64(downloaded),
+	})
+
+	return
+}
+
+// GetWhitelistedTorrents allows us to retrieve all of the white listed
+// torrents. Mostly used for populating the Redis KV storage with all of our
+// whitelisted torrents.
+func GetWhitelistedTorrents(dbConn *gorm.DB) (x *sql.Rows, err error) {
+	dbConn = assertOpenConnection(dbConn)
+
+	x, err = dbConn.Table("white_torrents").Rows()
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ScrapeTorrent supports the Scrape convention
+func ScrapeTorrent(dbConn *gorm.DB, infoHash string) (torrent *db.Torrent) {
+	dbConn = assertOpenConnection(dbConn)
+
+	dbConn.Where("info_hash = ?", infoHash).First(&torrent)
+	return
+}
+
+// formatConnectStrings concatenates the data from the config file into a
+// usable MySQL connection string.
+func formatConnectString(c config.ConfigStruct) string {
+	return fmt.Sprintf("%v:%v@tcp(%v:%v)/%v?parseTime=true",
+		c.MySQLUser,
+		c.MySQLPass,
+		c.MySQLHost,
+		c.MySQLPort,
+		c.MySQLDB,
+	)
+}
+
+// assertOpenConnection handles asserting a connection passed into a sql
+// function is open, not nil. If nil, we'll create a new connection.
+func assertOpenConnection(db *gorm.DB) *gorm.DB {
+	var err error
+
+	if db == nil {
+		db, err = OpenConnection()
+		if err != nil {
+			err = err
+		}
+	}
+
+	return db
+}

--- a/main.go
+++ b/main.go
@@ -1,18 +1,19 @@
 package main
 
 import (
-	"github.com/GrappigPanda/notorious/database"
+	"github.com/GrappigPanda/notorious/database/mysql"
 	"github.com/GrappigPanda/notorious/reaper"
 	"github.com/GrappigPanda/notorious/server"
 	"time"
 )
 
+// Init handles initialziation of the server.
 func Init() {
-	dbConn, err := db.OpenConnection()
+	dbConn, err := mysql.OpenConnection()
 	if err != nil {
 		panic("Failed to open connection to remote database.")
 	}
-	db.InitDB(dbConn)
+	mysql.InitDB(dbConn)
 
 	go reaper.StartReapingScheduler(1 * time.Minute)
 }

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -2,7 +2,7 @@ package reaper
 
 import (
 	"fmt"
-	"github.com/GrappigPanda/notorious/database"
+	"github.com/GrappigPanda/notorious/database/mysql"
 	r "github.com/GrappigPanda/notorious/kvStoreInterfaces"
 	"gopkg.in/redis.v3"
 	"strconv"
@@ -83,7 +83,7 @@ func StartReapingScheduler(waitTime time.Duration) {
 			addedBy := new(string)
 			dateAdded := new(int64)
 
-			x, err := db.GetWhitelistedTorrents(nil)
+			x, err := mysql.GetWhitelistedTorrents(nil)
 			for x.Next() {
 				x.Scan(infoHash, name, addedBy, dateAdded)
 				r.CreateNewTorrentKey(nil, *infoHash)


### PR DESCRIPTION
ADD:
  - database/impl/mysqlStore.go Houses the implementation (and wrappers of)
    `database/mysql/mysql.go` for `SQLStore`

CHANGE:
  - database/database.go Just houses `SQLStore` interface now.