### PR TITLE
Fixes #179

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,9 +5,9 @@
 UsePostgres: true
 UseMySQL: false
 DBHost: localhost
-DBPort: "5432"
-DBUser: postgres
-DBPass: postgres
+DBPort: "3306"
+DBUser: testuser
+DBPass: testuser
 DBName: testdb
 # Redis Options
 RedisServer: localhost

--- a/config.yaml
+++ b/config.yaml
@@ -5,9 +5,9 @@
 UsePostgres: true
 UseMySQL: false
 DBHost: localhost
-DBPort: "3306"
-DBUser: testuser
-DBPass: testuser 
+DBPort: "5432"
+DBUser: postgres
+DBPass: postgres
 DBName: testdb
 # Redis Options
 RedisServer: localhost

--- a/database/mysql/database_test.go
+++ b/database/mysql/database_test.go
@@ -18,14 +18,13 @@ var CONFIG = config.ConfigStruct{
 	false,
 }
 
-var DBCONN, _ = OpenConnectionWithConfig(&CONFIG)
+var DBCONN, ERR = OpenConnectionWithConfig(&CONFIG)
 
-func TestOpenConn(t *testing.T) {
-	dbConn, err := OpenConnection()
-	if err != nil {
-		t.Fatalf("%v", err)
+func TestOpenConnPostgres(t *testing.T) {
+	if ERR != nil {
+		t.Fatalf("Unable to connect %v", ERR)
 	}
-	InitDB(dbConn)
+	InitDB(DBCONN)
 }
 
 func TestAddWhitelistedTorrent(t *testing.T) {

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -14,13 +14,7 @@ import (
 // MysqlHost listed in the config
 func OpenConnection() (db *gorm.DB, err error) {
 	c := config.LoadConfig()
-
-	db, err = gorm.Open("mysql", formatConnectString(c))
-	if err != nil {
-		err = fmt.Errorf("Failed to open connection to MySQL: %v", err)
-	}
-
-	return
+	return OpenConnectionWithConfig(&c)
 }
 
 // OpenConnectionWithConfig does as its name dictates and opens a connection to the
@@ -28,10 +22,10 @@ func OpenConnection() (db *gorm.DB, err error) {
 func OpenConnectionWithConfig(cfg *config.ConfigStruct) (db *gorm.DB, err error) {
 	db, err = gorm.Open("mysql", formatConnectString(*cfg))
 	if err != nil {
-		err = fmt.Errorf("Failed to open connection to MySQL: %v", err)
+		return nil, fmt.Errorf("Failed to open connection to MySQL: %v", err)
 	}
 
-	return
+	return db, nil
 }
 
 // InitDB initializes database tables.

--- a/server/server.go
+++ b/server/server.go
@@ -156,11 +156,23 @@ func writeResponse(w http.ResponseWriter, values string) {
 
 // RunServer spins up the server and muxes the routes.
 func RunServer() {
+	// Load the config and initiate a `SQLStore` implementation.
+	var sqlObj db.SQLStore
+	cfg := config.LoadConfig()
+
+	if cfg.DBChoice == "mysql" {
+		sqlObj = new(sqlStoreImpl.MySQLStore)
+	} else if cfg.DBChoice == "postgres" {
+		sqlObj = new(sqlStoreImpl.PostgresStore)
+	} else {
+		panic("Invalid config value for DBChoice. Must be either postgres or MySQL.")
+	}
+
 	app := applicationContext{
-		config:          config.LoadConfig(),
+		config:          cfg,
 		trackerLevel:    a.RATIOLESS,
 		peerStoreClient: new(redisPeerStoreImpl.RedisStore),
-		sqlObj:          new(sqlStoreImpl.MySQLStore),
+		sqlObj:          sqlObj,
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
Changed default implementations of `mysql` found in the `reaper/reaper.go`
file. Now, depending on the config, we launch a new connection to whatever is
the specified database.

CHANGE:
  - config.yaml Now defaults to postgres (this is only important for my
    development environment.