### PR TITLE
Issue #189

### DIFF
--- a/database/schemas/torrent.go
+++ b/database/schemas/torrent.go
@@ -2,12 +2,13 @@ package schemas
 
 // Torrent houses the torrent schema information that we store in the DB.
 type Torrent struct {
-	id         int    `gorm:"AUTO_INCREMENT, unique, primary_key"`
-	InfoHash   string `gorm:"varchar(32), not null"`
-	Name       string `gorm:"not null"`
-	Downloaded int    `gorm:"not null"`
-	Seeders    int64  `gorm:"not null"`
-	Leechers   int64  `gorm:"not null"`
-	AddedBy    string `gorm:"varchar(15)"`
-	DateAdded  int64
+	id          int    `gorm:"AUTO_INCREMENT, unique, primary_key"`
+	InfoHash    string `gorm:"varchar(32), not null"`
+	Name        string `gorm:"not null"`
+	Downloaded  int    `gorm:"not null"`
+	Seeders     int64  `gorm:"not null"`
+	Leechers    int64  `gorm:"not null"`
+	AddedBy     string `gorm:"varchar(15)"`
+	Description string `gorm:"varchar(512)"`
+	DateAdded   int64
 }


### PR DESCRIPTION
ADD:
  - database/schemas/torrent.go Added a description field to the `Torrent`
    definition. This still needs to be moved out to a migration script, but
    this is fine for now.